### PR TITLE
feat: Auto-create browser zone on server startup

### DIFF
--- a/browser_tools.js
+++ b/browser_tools.js
@@ -304,14 +304,7 @@ let scraping_browser_scroll_to = {
     },
 };
 
-let browser_credentials;
-try {
-    browser_credentials = process.env.API_TOKEN ?
-        await calculate_cdp_endpoint() : null;
-} catch(e){
-    browser_credentials = null;
-}
-export const tools = browser_credentials ? [
+export const tools = process.env.API_TOKEN ? [
     scraping_browser_navigate,
     scraping_browser_go_back,
     scraping_browser_go_forward,

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const require = createRequire(import.meta.url);
 const package_json = require('./package.json');
 const api_token = process.env.API_TOKEN;
 const unlocker_zone = process.env.WEB_UNLOCKER_ZONE || 'mcp_unlocker';
+const browser_zone = process.env.BROWSER_ZONE || 'mcp_browser';
 
 function parse_rate_limit(rate_limit_str) {
     if (!rate_limit_str) 
@@ -64,6 +65,8 @@ async function ensure_required_zones(){
         });
         let zones = response.data || [];
         let has_unlocker_zone = zones.some(zone=>zone.name==unlocker_zone);
+        let has_browser_zone = zones.some(zone=>zone.name==browser_zone);
+        
         if (!has_unlocker_zone)
         {
             console.error(`Required zone "${unlocker_zone}" not found, `
@@ -84,6 +87,27 @@ async function ensure_required_zones(){
         }
         else
             console.error(`Required zone "${unlocker_zone}" already exists`);
+            
+        if (!has_browser_zone)
+        {
+            console.error(`Required zone "${browser_zone}" not found, `
+                +`creating it...`);
+            await axios({
+                url: 'https://api.brightdata.com/zone',
+                method: 'POST',
+                headers: {
+                    ...api_headers(),
+                    'Content-Type': 'application/json',
+                },
+                data: {
+                    zone: {name: browser_zone, type: 'browser_api'},
+                    plan: {type: 'browser_api'},
+                },
+            });
+            console.error(`Zone "${browser_zone}" created successfully`);
+        }
+        else
+            console.error(`Required zone "${browser_zone}" already exists`);
     } catch(e){
         console.error('Error checking/creating zones:',
             e.response?.data||e.message);


### PR DESCRIPTION
## Summary
This PR simplifies the setup process by automatically creating both unlocker and browser zones when the server starts. Users now only need to provide the API_TOKEN environment variable.

## Changes
- Added automatic browser zone creation in `ensure_required_zones()` function
- Set default browser zone name to `mcp_browser` (can be overridden with BROWSER_ZONE env var)
- Removed browser credentials check at module load time in browser_tools.js
- Browser tools are now exposed based on API_TOKEN presence rather than credential validation

## Testing
- Tested with a brand new account
- Both zones are created successfully on first run
- Browser tools are properly exposed after zone creation