### PR TITLE
Handling snapshot building status

### DIFF
--- a/server.js
+++ b/server.js
@@ -712,7 +712,7 @@ for (let {dataset_id, id, description, inputs, defaults = {}} of datasets)
                         method: 'GET',
                         headers: api_headers(),
                     });
-                    if (snapshot_response.data?.status === 'running')
+                    if (snapshot_response.data?.status === 'running' || snapshot_response.data?.status === 'building')
                     {
                         console.error(`[web_data_${id}] snapshot not ready, `
                             +`polling again (attempt `

--- a/server.js
+++ b/server.js
@@ -712,7 +712,7 @@ for (let {dataset_id, id, description, inputs, defaults = {}} of datasets)
                         method: 'GET',
                         headers: api_headers(),
                     });
-                    if (snapshot_response.data?.status === 'running' || snapshot_response.data?.status === 'building')
+                    if (['running', 'building'].includes(snapshot_response.data?.status))
                     {
                         console.error(`[web_data_${id}] snapshot not ready, `
                             +`polling again (attempt `


### PR DESCRIPTION
In some cases, the snapshot isn't ready and a final response is returned prematurely, resulting in invalid output. This pull request introduces a retry mechanism when the snapshot is still in the 'building' state (similar to 'running' state).