### PR TITLE
feat/search engine tool enhancment

### DIFF
--- a/server.js
+++ b/server.js
@@ -131,31 +131,54 @@ const addTool = (tool) => {
 
 addTool({
     name: 'search_engine',
-    description: 'Scrape search results from Google, Bing or Yandex. Returns '
-    +'SERP results in markdown (URL, title, description)',
+    description: 'Scrape search results from Google, Bing or Yandex. Returns ' +
+        `SERP results in JSON or Markdown (URL, title, description), Ideal for` +
+        `gathering current information, news, and detailed search results.`,
     parameters: z.object({
         query: z.string(),
-        engine: z.enum([
-            'google',
-            'bing',
-            'yandex',
-        ]).optional().default('google'),
-        cursor: z.string().optional().describe('Pagination cursor for next page'),
+        engine: z.enum(['google', 'bing', 'yandex'])
+            .optional()
+            .default('google'),
+        cursor: z.string()
+            .optional()
+            .describe('Pagination cursor for next page'),
     }),
-    execute: tool_fn('search_engine', async({query, engine, cursor})=>{
+    execute: tool_fn('search_engine', async ({ query, engine, cursor }) => {
+        const is_google = engine === 'google';
+        const url = is_google
+            ? `${search_url(engine, query, cursor)}&brd_json=1`
+            : search_url(engine, query, cursor);
         let response = await axios({
             url: 'https://api.brightdata.com/request',
             method: 'POST',
             data: {
-                url: search_url(engine, query, cursor),
+                url: url,
                 zone: unlocker_zone,
                 format: 'raw',
-                data_format: 'markdown',
+                data_format: is_google ? undefined : 'markdown',
             },
             headers: api_headers(),
             responseType: 'text',
         });
-
+        if (is_google) {
+            try {
+                const searchData = JSON.parse(response.data);
+                return JSON.stringify({
+                    organic: searchData.organic || [],
+                    images: searchData.images ? searchData.images.map(img => img.link) : [],
+                    current_page: searchData.pagination.current_page || {},
+                    related: searchData.related || [],
+                    ai_overview: searchData.ai_overview || null
+                });
+            } catch (e) {
+                return JSON.stringify({
+                    organic: [],
+                    images: [],
+                    pagination: {},
+                    related: []
+                });
+            }
+        }
         return response.data;
     }),
 });


### PR DESCRIPTION
Enhanced search_engine with addition - when the search engine is google, it uses brd_json=1 and extracts only relevant information.

Results :

15k tokens with raw markdown -> 1.5 tokens with the JSON , this is due to redundant information that returned in the markdown version and now works much better.