### PR TITLE
feat/add fixed values

### DIFF
--- a/server.js
+++ b/server.js
@@ -302,8 +302,8 @@ const datasets = [{
         'Requires a valid search keyword and amazon domain URL.',
         'This can be a cache lookup, so it can be more reliable than scraping',
     ].join('\n'),
-    inputs: ['keyword', 'url', 'pages_to_search'],
-    defaults: {pages_to_search: '1'},
+    inputs: ['keyword', 'url'],
+    fixed_values: {pages_to_search: '1'}, 
 }, {
     id: 'walmart_product',
     dataset_id: 'gd_l95fol7l1ru6rlo116',
@@ -673,7 +673,7 @@ const datasets = [{
     ].join('\n'),
     inputs: ['url'],
 }];
-for (let {dataset_id, id, description, inputs, defaults = {}} of datasets)
+for (let {dataset_id, id, description, inputs, defaults = {},fixed_values = {}} of datasets)
 {
     let parameters = {};
     for (let input of inputs)
@@ -687,6 +687,7 @@ for (let {dataset_id, id, description, inputs, defaults = {}} of datasets)
         description,
         parameters: z.object(parameters),
         execute: tool_fn(`web_data_${id}`, async(data, ctx)=>{
+            data = {...data, ...fixed_values};
             let trigger_response = await axios({
                 url: 'https://api.brightdata.com/datasets/v3/trigger',
                 params: {dataset_id, include_errors: true},


### PR DESCRIPTION
## Fix: Enforce fixed parameter values for high-token response tools

### Problem
Default values in tool parameters can be overridden when users explicitly request different values (e.g., "search 3 pages"). For tools like `amazon_product_search` that return large amounts of tokens, allowing pagination beyond page 1 can cause response size issues.

### Solution
Added `fixed_values` mechanism to enforce unchangeable parameter values at execution time, regardless of user input. This ensures certain parameters always use specified values even when explicitly overridden.

### Changes
- Added `fixed_values` property support to dataset definitions
- Applied `fixed_values: {pages_to_search: '1'}` to `amazon_product_search` 
- Values in `fixed_values` override any user-provided values at execution time

### Impact
- `amazon_product_search` now always uses 1 page regardless of user requests
- Framework is extensible for other high-token endpoints that need similar restrictions
- No breaking changes for tools without `fixed_values`