### PR TITLE
fix: Stop polling on HTTP 400 errors in web data tools

### DIFF
--- a/server.js
+++ b/server.js
@@ -736,6 +736,7 @@ for (let {dataset_id, id, description, inputs, defaults = {}} of datasets)
                 } catch(e){
                     console.error(`[web_data_${id}] polling error: `
                         +`${e.message}`);
+                    if (e.response?.status === 400) throw e;
                     attempts++;
                     await new Promise(resolve=>setTimeout(resolve, 1000));
                 }


### PR DESCRIPTION
## Problem
Web data tools were continuously polling and timing out when the API returned HTTP 400 errors (e.g., "Snapshot is empty"). This resulted in unnecessary API calls and long wait times before eventual timeout.

## Solution
Added a check to immediately fail on HTTP 400 responses in the polling loop. Since 400 errors indicate client errors that won't resolve with retrying, we now throw the error immediately instead of continuing to poll.

## Changes
- Added `if (e.response?.status === 400) throw e;` in the polling catch block
- Prevents endless polling when snapshots fail with client errors
- Reduces API calls and provides faster feedback to users

## Testing
Verified that failed snapshots (returning "Snapshot is empty" with HTTP 400) now fail immediately instead of timing out after 600 attempts.